### PR TITLE
Add deprecated library missing from install_requires

### DIFF
--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -580,7 +580,7 @@ class MLCommonClient:
             method="DELETE",
             url=API_URL,
         )
-    
+
     def create_connector(self, connector_payload: dict) -> dict:
         """
         This method creates a connector in the OpenSearch cluster using the ml-common plugin's API.
@@ -596,7 +596,7 @@ class MLCommonClient:
             url=API_URL,
             body=connector_payload,
         )
-    
+
     def delete_connector(self, connector_id: str) -> dict:
         """
         This method deletes a specific connector using its ID.
@@ -624,7 +624,6 @@ class MLCommonClient:
             method="GET",
             url=API_URL,
         )
-
 
     def search_connectors(self, search_payload: dict) -> dict:
         """

--- a/opensearch_py_ml/ml_commons/ml_commons_client.py
+++ b/opensearch_py_ml/ml_commons/ml_commons_client.py
@@ -580,3 +580,64 @@ class MLCommonClient:
             method="DELETE",
             url=API_URL,
         )
+    
+    def create_connector(self, connector_payload: dict) -> dict:
+        """
+        This method creates a connector in the OpenSearch cluster using the ml-common plugin's API.
+
+        :param connector_payload: Dictionary containing the details of the connector.
+        :type connector_payload: dict
+        :return: API response
+        :rtype: dict
+        """
+        API_URL = f"{ML_BASE_URI}/connectors/_create"
+        return self._client.transport.perform_request(
+            method="POST",
+            url=API_URL,
+            body=connector_payload,
+        )
+    
+    def delete_connector(self, connector_id: str) -> dict:
+        """
+        This method deletes a specific connector using its ID.
+
+        :param connector_id: ID of the connector to be deleted.
+        :type connector_id: str
+        :return: API response
+        :rtype: dict
+        """
+        API_URL = f"{ML_BASE_URI}/connectors/{connector_id}"
+        return self._client.transport.perform_request(
+            method="DELETE",
+            url=API_URL,
+        )
+
+    def list_connectors(self) -> dict:
+        """
+        This method lists all connectors in the OpenSearch cluster.
+
+        :return: API response containing a list of connectors.
+        :rtype: dict
+        """
+        API_URL = f"{ML_BASE_URI}/connectors"
+        return self._client.transport.perform_request(
+            method="GET",
+            url=API_URL,
+        )
+
+
+    def search_connectors(self, search_payload: dict) -> dict:
+        """
+        This method searches for connectors based on specific criteria.
+
+        :param search_payload: Dictionary containing search criteria.
+        :type search_payload: dict
+        :return: API response containing search results.
+        :rtype: dict
+        """
+        API_URL = f"{ML_BASE_URI}/connectors/_search"
+        return self._client.transport.perform_request(
+            method="POST",
+            url=API_URL,
+            body=search_payload,
+        )

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "pandas>=1.5,<3",
         "matplotlib>=3.6.0,<4",
         "numpy>=1.24.0,<2",
+        
         "deprecated",
     ],
     python_requires=">=3.8",

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ setup(
         "pandas>=1.5,<3",
         "matplotlib>=3.6.0,<4",
         "numpy>=1.24.0,<2",
-        
         "deprecated",
     ],
     python_requires=">=3.8",

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "pandas>=1.5,<3",
         "matplotlib>=3.6.0,<4",
         "numpy>=1.24.0,<2",
+        "deprecated",
     ],
     python_requires=">=3.8",
     package_data={"opensearch_py_ml": ["py.typed"]},

--- a/tests/ml_commons/test_ml_commons_client.py
+++ b/tests/ml_commons/test_ml_commons_client.py
@@ -6,8 +6,10 @@
 # GitHub history for details.
 
 import os
+import subprocess
 import shutil
 from os.path import exists
+import sys
 
 from opensearchpy import OpenSearch
 
@@ -389,7 +391,7 @@ def test_DEPRECATED_integration_model_train_upload_full_cycle():
                 except:  # noqa: E722
                     raised = True
                 assert raised == False, "Raised Exception in deleting model"
-
+    
 
 def test_integration_model_train_register_full_cycle():
     # first training the model with small epoch
@@ -514,5 +516,8 @@ def test_integration_model_train_register_full_cycle():
                     raised = True
                 assert raised == False, "Raised Exception in deleting model"
 
+    
+
 
 test_integration_model_train_register_full_cycle()
+


### PR DESCRIPTION
### Description
Adds deprecated library missing from install_requires
 
### Issues Resolved
Solves [BUG] deprecated library missing from install_requires list #315

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
